### PR TITLE
Version 0.3.0 : vérification des exemples, contraintes sur horaires

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @etalab/transport

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Publication d'une nouvelle version d'un schéma
+
+Vous publiez une nouvelle version d'un schéma ?
+Pensez à réaliser les actions suivantes.
+
+- [ ] Mettre à jour les fichiers d'exemples
+- [ ] Mettre à jour le champ `version`
+- [ ] Mettre à jour le champ `lastModified`
+- [ ] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
+- [ ] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
+- [ ] Merger cette pull-request
+- [ ] Publier un nouveau tag et une nouvelle version
+- [ ] Prévenir les utilisateurs de ce schéma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
-## Version 0.3.0 - 2022-02-24
+## Version 0.3.0 - 2022-03-16
 - Suppression du fichier Excel d'exemple
 - Correction de la valeur d'exemple pour `id_lieu`
 - Vérification de la validité de la colonne `horaires`
+- Autorisation des valeurs "vrai/faux" aux boleens : champ `ouvert` et `lumiere`
 
 ## Version 0.2.3 - 2022-02-09
 - Complétion de la description du champ "ouvert" du schéma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.3.0 - 2022-02-24
+- Suppression du fichier Excel d'exemple
+- Correction de la valeur d'exemple pour `id_lieu`
+- Vérification de la validité de la colonne `horaires`
+
 ## Version 0.2.3 - 2022-02-09
 - Complétion de la description du champ "ouvert" du schéma
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 - Suppression du fichier Excel d'exemple
 - Correction de la valeur d'exemple pour `id_lieu`
 - Vérification de la validité de la colonne `horaires`
-- Autorisation des valeurs "vrai/faux" aux boleens : champ `ouvert` et `lumiere`
+- Autorisation des valeurs `vrai` et `faux` pour les champs booléens (`ouvert` et `lumiere`)
 
 ## Version 0.2.3 - 2022-02-09
 - Complétion de la description du champ "ouvert" du schéma
@@ -21,7 +21,6 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 - colonne `id_lieu`, le mode de numérotation des aires est explicité
 - colonne `type`, ajout du type d'aire "Auto-stop"
 - colonne `source` devient facultative
-
 
 ## Version 0.1.2 - 2019-10-30
 - Enrichissements de la documentation : contexte, cadrage juridique, outils associés

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `idproducteur` est 
 ### Fichiers d'exemple
 Nous mettons à disposition des fichiers d'exemple qui peuvent servir de base pour renseigner vos lieux de covoiturage.
 
-- [Télécharger un fichier exemple au format CSV](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.2/exemple-valide.csv)
-- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.2/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
+- [Télécharger un fichier exemple au format CSV](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-valide.csv)
+- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
 
 ### Mises à jour
 Les mises à jour sont effectuées à partir du fichier communiqué précédemment et en reprennent, en les modifiant le cas échéant, les données qui y figurent déjà.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-frictionless==4.1
+frictionless==4.26.0

--- a/schema.json
+++ b/schema.json
@@ -166,7 +166,7 @@
         },
         {
             "name":"ouvert",
-            "description":"Le lieu est il actuellement accessible (actif ou inactif)",
+            "description":"Le lieu est-il actuellement accessible (actif ou inactif)",
             "example":"true",
             "type":"boolean",
             "constraints":{

--- a/schema.json
+++ b/schema.json
@@ -19,12 +19,12 @@
         {
           "title": "Ressource valide",
           "name": "exemple-valide",
-          "path": "https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.2/exemple-valide.csv"
+          "path": "https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-valide.csv"
         },
         {
           "title": "Ressource invalide",
           "name": "exemple-invalide",
-          "path": "https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.2/exemple-invalide.csv"
+          "path": "https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-invalide.csv"
         }
       ],
     "author":"Antoine Augusti pour Etalab",
@@ -73,17 +73,17 @@
             "role": "contributor"
         }
     ],
-    "version":"0.2.3",
+    "version":"0.3.0",
     "created":"2019-06-25",
-    "updated":"2022-02-09",
+    "updated":"2022-02-24",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
-    "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.3/schema.json",
-    "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.3/exemple-valide.csv",
+    "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/schema.json",
+    "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-valide.csv",
     "fields":[
         {
             "name":"id_lieu",
-            "description":"Identifiant du lieu de covoiturage, délivré par le point d'accès national selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001",
-            "example":"35238-C-001 pour la première aire référencée dans la commune de code INSEE 35238",
+            "description":"Identifiant du lieu de covoiturage, délivré par le point d'accès national selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001. Pour la première aire référencée dans la commune de code INSEE 35238, l'identifiant sera ainsi 35238-C-001.",
+            "example":"35238-C-001",
             "type":"string",
             "constraints":{
                 "required":true,
@@ -277,6 +277,12 @@
             "name":"french-siren-value",
             "params":{
                 "column":"source"
+            }
+        },
+        {
+            "name":"opening-hours-value",
+            "params":{
+                "column":"horaires"
             }
         }
     ],

--- a/schema.json
+++ b/schema.json
@@ -269,13 +269,13 @@
              "example":"true",
             "type":"boolean",
             "trueValues":[
-            "true",
-            "vrai"
-      ],
-           "falseValues":[
-           "false",
-           "faux"
-      ],
+                "true",
+                "vrai"
+            ],
+            "falseValues":[
+               "false",
+               "faux"
+            ],
             "constraints":{
                 "required":false
             }

--- a/schema.json
+++ b/schema.json
@@ -170,13 +170,13 @@
             "example":"true",
             "type":"boolean",
             "trueValues":[
-            "true",
-            "vrai"
-      ],
-           "falseValues":[
-           "false",
-           "faux"
-      ],
+                "true",
+                "vrai"
+            ],
+            "falseValues":[
+               "false",
+               "faux"
+            ],
             "constraints":{
                 "required":true
             }
@@ -266,13 +266,13 @@
             "description":"Un éclairage nocturne est-il présent",
             "example":false,
             "type":"boolean",
-             "example":"true",
-            "type":"boolean",
             "trueValues":[
+                true,
                 "true",
                 "vrai"
             ],
             "falseValues":[
+               false,
                "false",
                "faux"
             ],

--- a/schema.json
+++ b/schema.json
@@ -267,12 +267,10 @@
             "example":false,
             "type":"boolean",
             "trueValues":[
-                true,
                 "true",
                 "vrai"
             ],
             "falseValues":[
-               false,
                "false",
                "faux"
             ],

--- a/schema.json
+++ b/schema.json
@@ -75,7 +75,7 @@
     ],
     "version":"0.3.0",
     "created":"2019-06-25",
-    "updated":"2022-02-24",
+    "updated":"2022-03-16",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
     "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/schema.json",
     "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-valide.csv",
@@ -169,6 +169,14 @@
             "description":"Le lieu est-il actuellement accessible (actif ou inactif)",
             "example":"true",
             "type":"boolean",
+            "trueValues":[
+            "true",
+            "vrai"
+      ],
+           "falseValues":[
+           "false",
+           "faux"
+      ],
             "constraints":{
                 "required":true
             }
@@ -258,6 +266,16 @@
             "description":"Un éclairage nocturne est-il présent",
             "example":false,
             "type":"boolean",
+             "example":"true",
+            "type":"boolean",
+            "trueValues":[
+            "true",
+            "vrai"
+      ],
+           "falseValues":[
+           "false",
+           "faux"
+      ],
             "constraints":{
                 "required":false
             }


### PR DESCRIPTION
Au début j'étais parti pour mettre à jour frictionless vers 4.26.0 pour vérifier la cohérence des exemples du schéma, j'en ai profité pour :

- corriger la valeur d'exemple qui n'était pas valide
- utiliser [un custom check](https://git.opendatafrance.net/validata/validata-core/-/tree/master/validata_core/custom_checks) pour les horaires pour vérifier la validité
- tagguer une nouvelle version, ce qui n'avait pas encore été fait dans #18 