### PR TITLE
v0.2.6 : correction valeur d'exemple du champ id_lieu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @etalab/transport

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Publication d'une nouvelle version d'un schéma
+
+Vous publiez une nouvelle version d'un schéma ?
+Pensez à réaliser les actions suivantes.
+
+- [ ] Mettre à jour les fichiers d'exemples
+- [ ] Mettre à jour le champ `version`
+- [ ] Mettre à jour le champ `lastModified`
+- [ ] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
+- [ ] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
+- [ ] Merger cette pull-request
+- [ ] Publier un nouveau tag et une nouvelle version
+- [ ] Prévenir les utilisateurs de ce schéma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 ## Version 0.2.6 - 2022-08-26
 - Correction de la valeur d'exemple du champ `id_lieu`
 - Mise à jour d'outils
+- Dans les métadonnées du schéma, renomme le champ `updated` en `lastModified`
 
 ## Version 0.2.5 - 2022-08-26
 - Ajout d'une description sur la syntaxe attendue du champ `horaires` (au format "opening_hours" d'OSM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.2.6 - 2022-08-26
+- Correction de la valeur d'exemple du champ `id_lieu`
+- Mise à jour d'outils
+
 ## Version 0.2.5 - 2022-08-26
 - Ajout d'une description sur la syntaxe attendue du champ `horaires` (au format "opening_hours" d'OSM)
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `idproducteur` est 
 ### Fichiers d'exemple
 Nous mettons à disposition des fichiers d'exemple qui peuvent servir de base pour renseigner vos lieux de covoiturage.
 
-- [Télécharger un fichier exemple au format CSV](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.4/exemple-valide.csv)
-- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.4/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
+- [Télécharger un fichier exemple au format CSV](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/exemple-valide.csv)
+- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
 
 ### Mises à jour
 Les mises à jour sont effectuées à partir du fichier communiqué précédemment et en reprennent, en les modifiant le cas échéant, les données qui y figurent déjà.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-frictionless==4.1
+frictionless==4.40.8

--- a/schema.json
+++ b/schema.json
@@ -75,7 +75,7 @@
     ],
     "version":"0.2.6",
     "created":"2019-06-25",
-    "updated":"2022-08-26",
+    "lastModified":"2022-08-26",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
     "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/schema.json",
     "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/exemple-valide.csv",

--- a/schema.json
+++ b/schema.json
@@ -82,7 +82,7 @@
     "fields":[
         {
             "name":"id_lieu",
-            "description":"Identifiant du lieu de covoiturage, délivré par le point d'accès national selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001. L'identifiant 35238-C-001 désigne ainsi la première aire référencée dans la commune de code INSEE 35238.",
+            "description":"Identifiant du lieu de covoiturage, délivré par le Point d'Accès National selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001. L'identifiant 35238-C-001 désigne ainsi la première aire référencée dans la commune de code INSEE 35238.",
             "example":"35238-C-001",
             "type":"string",
             "constraints":{

--- a/schema.json
+++ b/schema.json
@@ -73,17 +73,17 @@
             "role": "contributor"
         }
     ],
-    "version":"0.2.5",
+    "version":"0.2.6",
     "created":"2019-06-25",
     "updated":"2022-08-26",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
-    "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.5/schema.json",
-    "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.5/exemple-valide.csv",
+    "uri":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/schema.json",
+    "example":"https://github.com/etalab/schema-lieux-covoiturage/raw/v0.2.6/exemple-valide.csv",
     "fields":[
         {
             "name":"id_lieu",
-            "description":"Identifiant du lieu de covoiturage, délivré par le point d'accès national selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001",
-            "example":"35238-C-001 pour la première aire référencée dans la commune de code INSEE 35238",
+            "description":"Identifiant du lieu de covoiturage, délivré par le point d'accès national selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001. L'identifiant 35238-C-001 désigne ainsi la première aire référencée dans la commune de code INSEE 35238.",
+            "example":"35238-C-001",
             "type":"string",
             "constraints":{
                 "required":true,
@@ -166,7 +166,7 @@
         },
         {
             "name":"ouvert",
-            "description":"Le lieu est il actuellement accessible (actif ou inactif)",
+            "description":"Le lieu est-il actuellement accessible (actif ou inactif)",
             "example":"true",
             "type":"boolean",
             "constraints":{


### PR DESCRIPTION
Fixes #23 

- Correction de la valeur d'exemple du champ `id_lieu`
- Mise à jour d'outils

# Publication d'une nouvelle version d'un schéma

Vous publiez une nouvelle version d'un schéma ?
Pensez à réaliser les actions suivantes.

- [x] Mettre à jour les fichiers d'exemples
- [x] Mettre à jour le champ `version`
- [x] Mettre à jour le champ `lastModified`
- [x] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
- [x] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
- [ ] Merger cette pull-request
- [ ] Publier un nouveau tag et une nouvelle version
- [ ] Prévenir les utilisateurs de ce schéma