### PR TITLE
Évolutions v0.3.0 : suppression id_lieu, id_local devient obligatoire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.3.0 - 2023-09-01
+- La colonne `id_lieu` est supprimée
+- La colonne `id_local` devient obligatoire
+- Mise à jour des exemples CSV correct/incorrect
+- Mise à jour du readme
+
 ## Version 0.2.8 - 2023-07-17
 - Correction de l'exemple CSV correct
 - Mise à jour des liens des exemples dans le `schema.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
-## Version 0.3.0 - 2023-09-01
+## Version 0.3.0 - 2023-12-18
 - La colonne `id_lieu` est supprimée
 - La colonne `id_local` devient obligatoire
 - Précision dans les valeurs booléennes possibles (`true` ou `false`uniquement)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.2.8 - 2023-07-17
+- Correction de l'exemple CSV correct
+- Mise à jour des liens des exemples dans le `schema.json`
+- Mise à jour du readme
+
+## Version 0.2.7 - 2023-04-13
+- Mise à jour du readme : ajout d'une information concernant la sécurité des aires
+
 ## Version 0.2.6 - 2022-08-26
 - Correction de la valeur d'exemple du champ `id_lieu`
 - Mise à jour d'outils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 ## Version 0.3.0 - 2023-09-01
 - La colonne `id_lieu` est supprimée
 - La colonne `id_local` devient obligatoire
+- Précision dans les valeurs booléennes possibles (`true` ou `false`uniquement)
 - Mise à jour des exemples CSV correct/incorrect
 - Mise à jour du README
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dans le but de constituer un répertoire national des lieux de covoiturage, ouve
 
 Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Contribution à la Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/producteurs/lieux-de-covoiturage/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
 
-En cas de contribution directement sur data.gopuv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données.
+En cas de contribution directement sur data.gouv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données. [Plus de détails sur l'ajout d'un schéma](https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/maitriser-les-schemas-de-donnees/indiquer-et-verifier-quune-ressource-respecte-un-schema-de-donnees)
 
 ### Format des fichiers
 Le fichier doit être un fichier CSV, encodé en UTF-8 et utilisant le point-virgule comme séparateur de colonnes. L'en-tête de colonne sur la première ligne est obligatoire. Tous les champs du schéma sont obligatoires ; si la donnée n'est pas disponible, la colonne doit malgré tout être présente mais vide.

--- a/README.md
+++ b/README.md
@@ -22,20 +22,18 @@ Les lieux de covoiturage sont des données précieuses, notamment pour les appli
 ## Transmission des données
 Dans le but de constituer un répertoire national des lieux de covoiturage, ouvert et accessible à tous, les collectivités peuvent transmettre systématiquement, sous forme de tableau mis à jour, les données relatives aux lieux qu'elles considèrent pertinents pour les covoitureurs.
 
-Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Contribution à la Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/producteurs/lieux-de-covoiturage/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
+Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Publier des données la Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/type-donnees/lieux-de-covoiturage/administration-des-donnees/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
 
 En cas de contribution directement sur data.gouv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données, afin que celui-ci soit ajouté automatiquement à la BNLC. [Plus de détails sur l'ajout d'un schéma](https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/maitriser-les-schemas-de-donnees/indiquer-et-verifier-quune-ressource-respecte-un-schema-de-donnees)
 
 ### Format des fichiers
 Le fichier doit être un fichier CSV, encodé en UTF-8 et utilisant la virgule comme séparateur de colonnes. L'en-tête de colonne sur la première ligne est obligatoire. Tous les champs du schéma sont obligatoires ; si la donnée n'est pas disponible, la colonne doit malgré tout être présente mais vide.
 
-Lorsque vous contribuez via data.gouv.fr, nous préconisons ce format de nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `AAAAMMJJ`est la date de mise à jour des données et `idproducteur` est le SIREN de la collectivité productrice des données. Par exemple pour le département de l'Ain, avec des données mises à jour le 18 juin 2023 :  `20230618_220100010_lieuxcovoit.csv`.
-
 ### Fichiers d'exemple
 Nous mettons à disposition des fichiers d'exemple qui peuvent servir de base pour renseigner vos lieux de covoiturage.
 
-- [Télécharger un fichier exemple valide au format CSV](https://github.com/etalab/lieux-covoiturage/blob/master/exemple-valide.csv)
-- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/lieux-covoiturage/blob/master/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
+- [Télécharger un fichier exemple valide au format CSV](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-valide.csv)
+- [Télécharger un fichier d'exemple invalide](https://github.com/etalab/schema-lieux-covoiturage/raw/v0.3.0/exemple-invalide.csv) contenant des erreurs dans le formatage des dates et une inversion des coordonnées géographiques latitude/longitude
 
 ### Mises à jour
 Les mises à jour sont effectuées à partir du fichier communiqué précédemment et en reprennent, en les modifiant le cas échéant, les données qui y figurent déjà.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Dans le but de constituer un répertoire national des lieux de covoiturage, ouve
 
 Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Contribution à la Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/producteurs/lieux-de-covoiturage/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
 
-En cas de contribution directement sur data.gouv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données. [Plus de détails sur l'ajout d'un schéma](https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/maitriser-les-schemas-de-donnees/indiquer-et-verifier-quune-ressource-respecte-un-schema-de-donnees)
+En cas de contribution directement sur data.gouv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données, afin que celui-ci soit ajouté automatiquement à la BNLC. [Plus de détails sur l'ajout d'un schéma](https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/maitriser-les-schemas-de-donnees/indiquer-et-verifier-quune-ressource-respecte-un-schema-de-donnees)
 
 ### Format des fichiers
-Le fichier doit être un fichier CSV, encodé en UTF-8 et utilisant le point-virgule comme séparateur de colonnes. L'en-tête de colonne sur la première ligne est obligatoire. Tous les champs du schéma sont obligatoires ; si la donnée n'est pas disponible, la colonne doit malgré tout être présente mais vide.
+Le fichier doit être un fichier CSV, encodé en UTF-8 et utilisant la virgule comme séparateur de colonnes. L'en-tête de colonne sur la première ligne est obligatoire. Tous les champs du schéma sont obligatoires ; si la donnée n'est pas disponible, la colonne doit malgré tout être présente mais vide.
 
 Lorsque vous contribuez via data.gouv.fr, nous préconisons ce format de nom du fichier : `AAAAMMJJ_idproducteur_lieuxcovoit.csv` où `AAAAMMJJ`est la date de mise à jour des données et `idproducteur` est le SIREN de la collectivité productrice des données. Par exemple pour le département de l'Ain, avec des données mises à jour le 18 juin 2023 :  `20230618_220100010_lieuxcovoit.csv`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Les lieux de covoiturage sont des données précieuses, notamment pour les appli
 ## Transmission des données
 Dans le but de constituer un répertoire national des lieux de covoiturage, ouvert et accessible à tous, les collectivités peuvent transmettre systématiquement, sous forme de tableau mis à jour, les données relatives aux lieux qu'elles considèrent pertinents pour les covoitureurs.
 
-Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Publier des données la Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/type-donnees/lieux-de-covoiturage/administration-des-donnees/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
+Les différents moyens permettant de contribuer sont détaillés dans la documentation "[Publier des données > La Base nationale des Lieux de Covoiturage (BNLC)](https://doc.transport.data.gouv.fr/type-donnees/lieux-de-covoiturage/administration-des-donnees/contribuer-a-la-base-nationale-des-lieux-de-covoiturage)".
 
 En cas de contribution directement sur data.gouv.fr, il faut sélectionner le schéma `Lieu de covoiturage` lors de la publication du jeu de données, afin que celui-ci soit ajouté automatiquement à la BNLC. [Plus de détails sur l'ajout d'un schéma](https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/maitriser-les-schemas-de-donnees/indiquer-et-verifier-quune-ressource-respecte-un-schema-de-donnees)
 

--- a/exemple-invalide.csv
+++ b/exemple-invalide.csv
@@ -1,3 +1,3 @@
-id_lieu,id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
-76217-C-001,23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,Correspondance avec la ligne TER Dieppe-Rouen
-76217-C-002,23X02,Gare Routière de Dieppe,2 Avenue Victor Louis,Dieppe,76000,Parking,24-06-2019,true,576578587,49.921921,1.065656,2,3,,false,Ville de Dieppe,true,Proximité de la gare SNCF
+id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
+23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,Correspondance avec la ligne TER Dieppe-Rouen
+23X02,Gare Routière de Dieppe,2 Avenue Victor Louis,Dieppe,76000,Parking,24-06-2019,true,576578587,49.921921,1.065656,2,3,,false,Ville de Dieppe,true,Proximité de la gare SNCF

--- a/exemple-invalide.csv
+++ b/exemple-invalide.csv
@@ -1,3 +1,3 @@
-id_lieu;id_local;nom_lieu;ad_lieu;com_lieu;insee;type;date_maj;ouvert;source;Xlong;Ylat;nbre_pl;nbre_pmr;duree;horaires;proprio;lumiere;comm
-76217-C-001;23X01;Gare SNCF de Dieppe;2 Boulevard Georges Clemenceau;Dieppe;76217;Parking;2019-06-25;true;217602176;1.081183;49.921823;20;2;;true;Ville de Dieppe;true;Correspondance avec la ligne TER Dieppe-Rouen
-76217-C-002;23X02;Gare Routière de Dieppe;2 Avenue Victor Louis;Dieppe;76000;Parking;24-06-2019;true;576578587;49.921921;1.065656;2;3;;false;Ville de Dieppe;true;Proximité de la gare SNCF
+id_lieu,id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
+76217-C-001,23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,Correspondance avec la ligne TER Dieppe-Rouen
+76217-C-002,23X02,Gare Routière de Dieppe,2 Avenue Victor Louis,Dieppe,76000,Parking,24-06-2019,true,576578587,49.921921,1.065656,2,3,,false,Ville de Dieppe,true,Proximité de la gare SNCF

--- a/exemple-valide.csv
+++ b/exemple-valide.csv
@@ -1,2 +1,2 @@
-id_lieu;id_local;nom_lieu;ad_lieu;com_lieu;insee;type;date_maj;ouvert;source;Xlong;Ylat;nbre_pl;nbre_pmr;duree;horaires;proprio;lumiere;comm
-"76217-C-001";;Gare SNCF de Dieppe;2 Boulevard Georges Clemenceau;Dieppe;76217;Parking;2019-06-25;true;217602176;1.081183;49.921823;20;2;;true;Ville de Dieppe;true;"Correspondance avec la ligne TER Dieppe-Rouen"
+id_lieu,id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
+"76217-C-001",,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,"Correspondance avec la ligne TER Dieppe-Rouen"

--- a/exemple-valide.csv
+++ b/exemple-valide.csv
@@ -1,2 +1,2 @@
-id_lieu,id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
-"76217-C-001",,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,"Correspondance avec la ligne TER Dieppe-Rouen"
+id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
+23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,"Correspondance avec la ligne TER Dieppe-Rouen"

--- a/exemple-valide.csv
+++ b/exemple-valide.csv
@@ -1,2 +1,2 @@
 id_local,nom_lieu,ad_lieu,com_lieu,insee,type,date_maj,ouvert,source,Xlong,Ylat,nbre_pl,nbre_pmr,duree,horaires,proprio,lumiere,comm
-23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,"Correspondance avec la ligne TER Dieppe-Rouen"
+23X01,Gare SNCF de Dieppe,2 Boulevard Georges Clemenceau,Dieppe,76217,Parking,2019-06-25,true,217602176,1.081183,49.921823,20,2,,true,Ville de Dieppe,true,Correspondance avec la ligne TER Dieppe-Rouen

--- a/schema.json
+++ b/schema.json
@@ -32,7 +32,7 @@
     "contributors": [
         {
             "title": "Miryad Ali, Francis Chabouis, Aurélien Cadiou",
-            "email": "contact@transport.beta.gouv.fr",
+            "email": "contact@transport.data.gouv.fr",
             "organisation": "transport.data.gouv.fr",
             "role": "contributor"
         },

--- a/schema.json
+++ b/schema.json
@@ -75,7 +75,7 @@
     ],
     "version":"0.3.0",
     "created":"2019-06-25",
-    "lastModified":"2023-09-01",
+    "lastModified":"2023-10-06",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
     "uri":"https://github.com/etalab/lieux-covoiturage/blob/master/schema.json",
     "example":"https://github.com/etalab/lieux-covoiturage/blob/master/exemple-valide.csv",
@@ -160,7 +160,9 @@
             "example":"true",
             "type":"boolean",
             "constraints":{
-                "required":true
+                "required":true,
+                "trueValues": ["true"],
+                "falseValues": ["false"]
             }
         },
         {
@@ -249,7 +251,9 @@
             "example":false,
             "type":"boolean",
             "constraints":{
-                "required":false
+                "required":false,
+                "trueValues": ["true"],
+                "falseValues": ["false"]
             }
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -159,10 +159,10 @@
             "description":"Le lieu est-il actuellement accessible (actif ou inactif)",
             "example":"true",
             "type":"boolean",
+            "trueValues": ["true"],
+            "falseValues": ["false"],
             "constraints":{
-                "required":true,
-                "trueValues": ["true"],
-                "falseValues": ["false"]
+                "required":true
             }
         },
         {
@@ -250,10 +250,10 @@
             "description":"Un éclairage nocturne est-il présent",
             "example":false,
             "type":"boolean",
+            "trueValues": ["true"],
+            "falseValues": ["false"],
             "constraints":{
-                "required":false,
-                "trueValues": ["true"],
-                "falseValues": ["false"]
+                "required":false
             }
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -31,7 +31,7 @@
     "contact":"contact@transport.beta.gouv.fr",
     "contributors": [
         {
-            "title": "Miryad Ali et Francis Chabouis",
+            "title": "Miryad Ali, Francis Chabouis, Aurélien Cadiou",
             "email": "contact@transport.beta.gouv.fr",
             "organisation": "transport.data.gouv.fr",
             "role": "contributor"
@@ -73,30 +73,20 @@
             "role": "contributor"
         }
     ],
-    "version":"0.2.8",
+    "version":"0.3.0",
     "created":"2019-06-25",
-    "lastModified":"2023-07-17",
+    "lastModified":"2023-09-01",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
     "uri":"https://github.com/etalab/lieux-covoiturage/blob/master/schema.json",
     "example":"https://github.com/etalab/lieux-covoiturage/blob/master/exemple-valide.csv",
     "fields":[
-        {
-            "name":"id_lieu",
-            "description":"Identifiant du lieu de covoiturage, délivré par le Point d'Accès National selon la règle INSEE-C-XXX où INSEE est le code INSEE de la commune et XXX est le numéro d’ordre d'arrivée dans la base sur 3 chiffres, commençant par 001. L'identifiant 35238-C-001 désigne ainsi la première aire référencée dans la commune de code INSEE 35238.",
-            "example":"35238-C-001",
-            "type":"string",
-            "constraints":{
-                "required":true,
-                "pattern":"^([013-9]\\d|2[AB1-9])\\d{3}-C-\\d{3}$"
-            }
-        },
         {
             "name":"id_local",
             "description":"Identifiant du lieu de covoiturage fixé par le producteur de la donnée pour son propre usage",
             "example":"23X01",
             "type":"string",
             "constraints":{
-                "required":false
+                "required":true
             }
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -73,9 +73,9 @@
             "role": "contributor"
         }
     ],
-    "version":"0.2.7",
+    "version":"0.2.8",
     "created":"2019-06-25",
-    "lastModified":"2023-01-24",
+    "lastModified":"2023-07-17",
     "homepage":"https://github.com/etalab/schema-lieux-covoiturage",
     "uri":"https://github.com/etalab/lieux-covoiturage/blob/master/schema.json",
     "example":"https://github.com/etalab/lieux-covoiturage/blob/master/exemple-valide.csv",


### PR DESCRIPTION
Evolutions du schéma vers une nouvelle version v0.3.0

L'obectif est d'avoir un schéma adapté à l'évolution prévue du mécanisme de contribution à la BNLC. L'évolution va permettre la consolidation automatique des jeux de données sur data.gouv.fr dans la BNLC. Lien : https://github.com/etalab/transport-site/issues/3419

Cela implique, notamment : 
- de supprimer la colonne `id_lieu`, qui sera présente uniquement dans la BNLC, mais plus dans les jeux de données individuels ;
- de rendre obligatoire la colonne `id_local`, afin qu'un identifiant reste présent.
